### PR TITLE
added room id to "section" title

### DIFF
--- a/crates/scitool-cli/src/generate/html.rs
+++ b/crates/scitool-cli/src/generate/html.rs
@@ -77,7 +77,7 @@ fn generate_section(_level: usize, section: &Section) -> maud::Markup {
     maud::html! {
         .section id=[section.id()] {
             ."section-title" {
-                (generate_rich_text(section.title()))
+                (generate_rich_text(&format!("{} - {}", section.title(), section.id().unwrap_or(""))))
                 @if let Some(id) = section.id() {
                     (generate_copy_button(id))
                 }


### PR DESCRIPTION
I have no experience with Rust, but from what I gather this will work? I wasn't sure about the "unwrap_or("") bit but I wanted to add something in case for whatever reason there wasn't a room id for that section. Happy to hear your thoughts.